### PR TITLE
Link colours now working

### DIFF
--- a/code/00-sandbox.R
+++ b/code/00-sandbox.R
@@ -9,15 +9,15 @@ links <- test$links
 map = setNames(c(0: (length(test$nodes$name)-1)), c(test$nodes$name))
 links$source <- map[unlist(test$links$source)]
 links$target <- map[unlist(test$links$target)]
-links$group <- as.factor(map[unlist(test$links$group)])
+links$group <- as.character(test$links$group)
 
-my_color <- 'd3.scaleOrdinal() .domain(["1", "2"]) .range(["red", "purple"])'
+my_color <- 'd3.scaleOrdinal() .domain(["1", "2", "hos", "icu", "lab", "inst", "report"]) .range(["#85992C", "#E7FF7D", "#CCE65A", "#6C1D99", "#B25AE6", "navy", "orange", "yellow"])'
 
 p <- sankeyNetwork(Links = links, Nodes = test$nodes, Source = "source",
                    Target = "target", Value = "value", NodeID = "name",
                    sinksRight	= FALSE,
-                   # LinkGroup = "group",
-                   # colourScale=my_color,
+                   LinkGroup = "group",
+                   colourScale=my_color,
                    fontSize = 18, nodeWidth = 45, 
                    NodeGroup = "group", 
                    nodePadding = 13, iterations = 100)


### PR DESCRIPTION
Popravil:
 - grupe na linkih dodal kot stringe, ne faktorje (surove vrednosti niso ok, ker so številke, grupe pa morajo biti stringi)
 - dodal še par naključnih barv za grupe od node-ov
 - odkomentiral zakomentirano kodo za nastavljanje barv

POC: https://imgur.com/a/VtUh1ND

Kako pobarvati linke:
 - v master.json poišči link, ki ga želiš pobarvati, in mu določi grupo
 - v sprejemljivki my_color za to grupo nastavi barvo